### PR TITLE
Removed #include <sys/ioctl.h>

### DIFF
--- a/main.c
+++ b/main.c
@@ -14,7 +14,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <stdarg.h>
 #include <stdlib.h>

--- a/xbedump.c
+++ b/xbedump.c
@@ -16,7 +16,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <stdarg.h>
 #include <stdlib.h>

--- a/xbevalidate.c
+++ b/xbevalidate.c
@@ -15,7 +15,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <stdarg.h>
 #include <stdlib.h>

--- a/xboxlib.c
+++ b/xboxlib.c
@@ -14,7 +14,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <stdarg.h>
 #include <stdlib.h>


### PR DESCRIPTION
I attempted to build xbedump using MSYS2 on Windows and ran into a problem where `ioctl.h` is not found:

```
$ make
rm -f *.o  xbe core
g++ -O2 -ansi -o giants.o -c giants.c
g++ -O2 -ansi -o sha1.o -c sha1.c
g++ -O2 -ansi -o xboxlib.o -c xboxlib.c
xboxlib.c:17:10: fatal error: sys/ioctl.h: No such file or directory
 #include <sys/ioctl.h>
          ^~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:13: xboxlib.o] Fehler 1
--------------------------------------------------------------------
```
As this include file does not appear to be necessary, this PR removes references it.

After removing it in the files:
```
$ make
rm -f *.o  xbe core
g++ -O2 -ansi -o giants.o -c giants.c
g++ -O2 -ansi -o sha1.o -c sha1.c
g++ -O2 -ansi -o xboxlib.o -c xboxlib.c
g++ -O2 -ansi -o xbedump.o -c xbedump.c
g++ -O2 -ansi -o xbevalidate.o -c xbevalidate.c
g++ -O2 -ansi -o main.o -c main.c
g++ -o xbe -lm giants.o sha1.o xboxlib.o xbedump.o  xbevalidate.o main.o
```
