### PR TITLE
Fix `gigimport` in RSA

### DIFF
--- a/xboxlib.c
+++ b/xboxlib.c
@@ -184,16 +184,21 @@ int read_rsafrombin_asterix()
 	return 0;
 }    
 
-void gigimport(giant g, unsigned char *buff, int len) {
+void gigimport(giant g, const unsigned char *buff, int len) {
 
 	// copy buffered 'number' into giant's number buffer
 	memcpy(g->n, buff, len);
 
 	assert((len % 2) == 0);
 
+	// Get number of shorts
 	g->sign = len / 2;
 
-	assert(g->sign != 0);
+	// Only count used shorts
+	while((g->sign >= 1) && (g->n[g->sign - 1] == 0)) {
+		g->sign -= 1;
+	}
+
 }
 
 // DE - Crypting


### PR DESCRIPTION
Backport of changes that were done in https://github.com/Cxbx-Reloaded/Cxbx-Reloaded/pull/1561

Additionally, an assert was removed because it warns about (what appears to be) a valid state. See this discussion on this PR: https://github.com/XboxDev/xbedump/pull/11#discussion_r291654891

Hopefully closes #9 and hopefully closes #10 