### PR TITLE
fix stack corruption when signing with Habibi key

### DIFF
--- a/xboxlib.c
+++ b/xboxlib.c
@@ -432,7 +432,7 @@ int generate_habibi(void){
 	invg(phi,p);
         memcpy(&Testkey[20+256],p->n,256);
 	//gout(phi);
-
+	return 0;
 }
 
 


### PR DESCRIPTION
Fixes stack corruption caused by a missing return value from a function declared as `int`.

This prevents a segfault when using the -habibi command-line option